### PR TITLE
Add close button to preferences dialog

### DIFF
--- a/chrome/content/pref/main.xul
+++ b/chrome/content/pref/main.xul
@@ -35,5 +35,10 @@
                 <button label="Wählen..." oncommand="prefMain.chooseFolder();"/>
             </hbox>
         </groupbox>
+
+        <hbox>
+            <spacer flex="1"/>
+            <button label="Schließen" oncommand="window.close();"/>
+        </hbox>
     </prefpane>
 </overlay>


### PR DESCRIPTION
On Mac I did not find a way to close the preferences dialog, so I added a simple close button
