### PR TITLE
support firefox-bin executable to start geierlein

### DIFF
--- a/bin/xgeierlein.in
+++ b/bin/xgeierlein.in
@@ -19,7 +19,7 @@ EOF
   exit 0
 fi
 
-for search in firefox iceweasel xulrunner; do
+for search in firefox firefox-bin iceweasel xulrunner; do
   if [ "$XULRUNNER" = "" ]; then
     XULRUNNER="$(which $search)"
   fi


### PR DESCRIPTION
Some distributions (e.g. Gentoo) have a firefox-bin package using firefox-bin also as the executable name. Let geierlein execution script work with that.