### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ tested against it (or you use an old version).
 
 The maximum version number can easily be edited in the application.ini
 file.  You can just bump it to whichever version of Firefox you use.
-Simply keep in mind that you might come accross incompatibilities due
+Simply keep in mind that you might come across incompatibilities due
 to changed Firefox APIs.  In that case simply open an issue ticket at
 GitHub.
 


### PR DESCRIPTION
@stesie, I've corrected a typographical error in the documentation of the [geierlein](https://github.com/stesie/geierlein) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.